### PR TITLE
Orders search/export + fix silent SITE_URL callback misconfig

### DIFF
--- a/convex/orders_node_actions.ts
+++ b/convex/orders_node_actions.ts
@@ -26,6 +26,26 @@ export const createPaymentRecord = action({
   ): Promise<{ paymentId: string; paymentData: any }> => {
     const now = Date.now();
 
+    // Validate environment variables at runtime to avoid throwing during
+    // Convex module analysis.
+    validateSigningEnvs();
+
+    // SITE_URL feeds both the callbackUrl Jenga is told to POST to and the
+    // signature data. If it's missing or malformed, Jenga can never reach
+    // our webhook and the resulting payment will be stuck "pending"
+    // forever with no error anywhere. Fail loudly instead.
+    const siteUrl = process.env.SITE_URL;
+    if (!siteUrl || !/^https?:\/\/[^/]+/.test(siteUrl) || siteUrl.endsWith("/")) {
+      const message =
+        `[createPaymentRecord] Invalid or missing SITE_URL Convex env var: "${siteUrl ?? "undefined"}". ` +
+        `Set it to the production site origin (e.g. https://example.com, no trailing slash) via ` +
+        `\`npx convex env set SITE_URL https://your-domain --prod\`. Aborting to avoid an orphaned payment with a broken callbackUrl.`;
+      console.error(message);
+      throw new Error(message);
+    }
+
+    const callbackUrl = `${siteUrl}/api/pgw-webhook-4365c21f`;
+
     // Generate payment token (external API call - this is why we need an action)
     const token = await generateAccessToken();
 
@@ -36,11 +56,7 @@ export const createPaymentRecord = action({
 
     const cleanRef = sanitizeReference(args.orderReference);
 
-    // Validate environment variables in production only at runtime to avoid
-    // throwing during Convex module analysis.
-    validateSigningEnvs();
-
-    const signatureData = `${process.env.JENGA_MERCHANT_CODE || ""}${cleanRef}KES${String(args.orderAmount)}${process.env.SITE_URL ? `${process.env.SITE_URL}/api/pgw-webhook-4365c21f` : "http://localhost:3000/api/pgw-webhook-4365c21f"}`;
+    const signatureData = `${process.env.JENGA_MERCHANT_CODE || ""}${cleanRef}KES${String(args.orderAmount)}${callbackUrl}`;
 
     const privateKey = loadPrivateKeyFromEnvOrFile();
     const signature = privateKey
@@ -63,7 +79,7 @@ export const createPaymentRecord = action({
       customerEmail: args.customerEmail,
       customerPhone: args.customerPhone,
       countryCode: "KE",
-      callbackUrl: `${process.env.SITE_URL}/api/pgw-webhook-4365c21f`,
+      callbackUrl,
       secondaryReference: cleanRef,
       signature,
       status: "pending",

--- a/convex/utils/signing.ts
+++ b/convex/utils/signing.ts
@@ -61,15 +61,15 @@ export function verifyJengaSignatureBase64(
 // Do not run expensive or throwing checks at module load time because the Convex
 // bundler analyzes modules during deployment. Export a validator function and
 // call it at runtime from actions that require these env vars.
+//
+// SITE_URL is validated separately (and more strictly) in
+// orders_node_actions.ts, since it also needs URL-shape validation. This
+// function only covers JENGA_MERCHANT_CODE, which feeds the signature
+// unconditionally and has the same silent-failure risk if missing.
 export function validateSigningEnvs(): void {
-  if (process.env.NODE_ENV === "production") {
-    const missing: string[] = [];
-    if (!process.env.JENGA_MERCHANT_CODE) missing.push("JENGA_MERCHANT_CODE");
-    if (!process.env.SITE_URL) missing.push("SITE_URL");
-    if (missing.length) {
-      throw new Error(
-        `Missing required environment variables for Jenga signing in production: ${missing.join(", ")}. Aborting to avoid signature mismatch.`,
-      );
-    }
+  if (!process.env.JENGA_MERCHANT_CODE) {
+    throw new Error(
+      "Missing required environment variable JENGA_MERCHANT_CODE for Jenga signing. Aborting to avoid signature mismatch.",
+    );
   }
 }

--- a/src/app/manage/page.tsx
+++ b/src/app/manage/page.tsx
@@ -724,8 +724,7 @@ function DashboardContent() {
                       </tr>
                     </thead>
                     <tbody>
-                      {filteredOrders &&
-                        filteredOrders.map((order: Order) => (
+                      {filteredOrders.map((order: Order) => (
                           <tr key={order._id} className="border-t">
                             <td className="p-3 sm:p-4">
                               <code className="text-xs bg-gray-100 px-2 py-1 rounded">

--- a/src/app/manage/page.tsx
+++ b/src/app/manage/page.tsx
@@ -7,7 +7,10 @@ import { api } from "../../../convex/_generated/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { toCsv, downloadCsv, type CsvValue } from "@/lib/csv";
 import { SignInButton, UserButton, useUser } from "@clerk/nextjs";
 import {
   Users,
@@ -27,16 +30,75 @@ import {
 interface Order {
   _id: string;
   orderReference: string;
+  student?: string;
+  university?: string;
+  yearOfStudy?: string;
+  regNumber?: string;
+  attending?: string;
   name: string;
   email: string;
   phone?: string;
+  nameOfKin?: string;
+  kinNumber?: string;
+  medicalCondition?: string;
+  pickUp?: string;
   tshirtType: string;
   tshirtSize: string;
   quantity: number;
   totalAmount: number;
+  salesAgentName?: string;
   paid: boolean;
   createdAt: number;
 }
+
+const ORDER_EXPORT_COLUMNS: {
+  key: keyof Order;
+  label: string;
+  format?: (order: Order) => string | number;
+}[] = [
+  { key: "orderReference", label: "Order Reference" },
+  { key: "name", label: "Name" },
+  { key: "email", label: "Email" },
+  { key: "phone", label: "Phone" },
+  { key: "university", label: "University" },
+  { key: "student", label: "Student" },
+  { key: "yearOfStudy", label: "Year of Study" },
+  { key: "regNumber", label: "Registration Number" },
+  { key: "attending", label: "Attending" },
+  { key: "tshirtType", label: "T-Shirt Type" },
+  { key: "tshirtSize", label: "T-Shirt Size" },
+  { key: "quantity", label: "Quantity" },
+  { key: "totalAmount", label: "Total Amount (KES)" },
+  { key: "salesAgentName", label: "Sales Agent" },
+  { key: "nameOfKin", label: "Next of Kin" },
+  { key: "kinNumber", label: "Kin Number" },
+  { key: "medicalCondition", label: "Medical Condition" },
+  { key: "pickUp", label: "Pick Up Location" },
+  {
+    key: "paid",
+    label: "Payment Status",
+    format: (o) => (o.paid ? "Paid" : "Pending"),
+  },
+  {
+    key: "createdAt",
+    label: "Created At",
+    format: (o) => new Date(o.createdAt).toISOString(),
+  },
+];
+
+const DEFAULT_EXPORT_COLUMN_KEYS: (keyof Order)[] = [
+  "orderReference",
+  "name",
+  "email",
+  "phone",
+  "university",
+  "tshirtType",
+  "tshirtSize",
+  "quantity",
+  "totalAmount",
+  "paid",
+  "createdAt",
+];
 
 interface Payment {
   _id: string;
@@ -63,6 +125,11 @@ function DashboardContent() {
     reconciled?: number;
     skipped?: number;
   } | null>(null);
+  const [orderSearch, setOrderSearch] = useState("");
+  const [exportColumns, setExportColumns] = useState<Set<keyof Order>>(
+    new Set(DEFAULT_EXPORT_COLUMN_KEYS),
+  );
+  const [exportPopoverOpen, setExportPopoverOpen] = useState(false);
   const { user } = useUser();
 
   // Fetch data from Convex - now safe to call
@@ -275,6 +342,18 @@ function DashboardContent() {
       setReconcileLoading(false);
     }
   };
+
+  const filteredOrders = (orders ?? []).filter((order: Order) => {
+    if (!orderSearch.trim()) return true;
+    const q = orderSearch.trim().toLowerCase();
+    return [
+      order.orderReference,
+      order.name,
+      order.email,
+      order.phone,
+      order.university,
+    ].some((field) => field?.toLowerCase().includes(q));
+  });
 
   return (
     <div className="min-h-screen bg-secondary py-4 sm:py-6 lg:py-8">
@@ -540,13 +619,79 @@ function DashboardContent() {
               <h2 className="text-xl sm:text-2xl font-bold text-foreground">
                 Order Management
               </h2>
-              <div className="flex gap-2">
+              <div className="flex flex-col sm:flex-row sm:items-center gap-2">
                 <Badge variant="outline">
                   {totalOrders.toLocaleString()} Total Orders
                 </Badge>
                 <Badge variant="outline" className="bg-green-50 text-green-700">
                   {paidOrders.toLocaleString()} Paid
                 </Badge>
+                <Input
+                  placeholder="Search by ref, name, email, phone, university..."
+                  value={orderSearch}
+                  onChange={(e) => setOrderSearch(e.target.value)}
+                  className="sm:w-64"
+                />
+                <Popover open={exportPopoverOpen} onOpenChange={setExportPopoverOpen}>
+                  <PopoverTrigger asChild>
+                    <Button variant="outline" size="sm">
+                      Export CSV
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-64" align="end">
+                    <p className="text-sm font-medium mb-2">Columns to export</p>
+                    <div className="space-y-1 max-h-64 overflow-y-auto">
+                      {ORDER_EXPORT_COLUMNS.map((col) => (
+                        <label
+                          key={col.key}
+                          className="flex items-center gap-2 text-sm"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={exportColumns.has(col.key)}
+                            onChange={(e) => {
+                              const next = new Set(exportColumns);
+                              if (e.target.checked) next.add(col.key);
+                              else next.delete(col.key);
+                              setExportColumns(next);
+                            }}
+                          />
+                          {col.label}
+                        </label>
+                      ))}
+                    </div>
+                    <Button
+                      size="sm"
+                      className="w-full mt-3"
+                      disabled={exportColumns.size === 0}
+                      onClick={() => {
+                        const cols = ORDER_EXPORT_COLUMNS.filter((c) =>
+                          exportColumns.has(c.key),
+                        );
+                        const rows = filteredOrders.map((order: Order) => {
+                          const row: Record<string, CsvValue> = {};
+                          cols.forEach((c) => {
+                            row[c.key as string] = c.format
+                              ? c.format(order)
+                              : ((order[c.key] as CsvValue) ?? "");
+                          });
+                          return row;
+                        });
+                        const csv = toCsv(
+                          rows,
+                          cols.map((c) => ({ key: c.key as string, label: c.label })),
+                        );
+                        downloadCsv(
+                          `orders-export-${new Date().toISOString().slice(0, 10)}.csv`,
+                          csv,
+                        );
+                        setExportPopoverOpen(false);
+                      }}
+                    >
+                      Download CSV ({filteredOrders.length} rows)
+                    </Button>
+                  </PopoverContent>
+                </Popover>
               </div>
             </div>
             <Card>
@@ -568,7 +713,7 @@ function DashboardContent() {
                           Amount
                         </th>
                         <th className="text-left p-3 sm:p-4 font-semibold text-sm sm:text-base">
-                          Status
+                          University
                         </th>
                         <th className="text-left p-3 sm:p-4 font-semibold text-sm sm:text-base">
                           Date
@@ -579,8 +724,8 @@ function DashboardContent() {
                       </tr>
                     </thead>
                     <tbody>
-                      {orders &&
-                        orders.map((order: Order) => (
+                      {filteredOrders &&
+                        filteredOrders.map((order: Order) => (
                           <tr key={order._id} className="border-t">
                             <td className="p-3 sm:p-4">
                               <code className="text-xs bg-gray-100 px-2 py-1 rounded">
@@ -617,16 +762,9 @@ function DashboardContent() {
                               </span>
                             </td>
                             <td className="p-3 sm:p-4">
-                              <Badge
-                                variant={order.paid ? "default" : "outline"}
-                                className={
-                                  order.paid
-                                    ? "bg-green-600 text-white"
-                                    : "bg-yellow-100 text-yellow-800"
-                                }
-                              >
-                                {order.paid ? "Paid" : "Pending"}
-                              </Badge>
+                              <span className="text-sm">
+                                {order.university || "-"}
+                              </span>
                             </td>
                             <td className="p-3 sm:p-4">
                               <p className="text-sm">
@@ -653,6 +791,14 @@ function DashboardContent() {
                       <p>No orders found</p>
                     </div>
                   )}
+                  {orders &&
+                    orders.length > 0 &&
+                    filteredOrders.length === 0 && (
+                      <div className="p-8 text-center text-slate-500">
+                        <Package className="w-12 h-12 mx-auto mb-4 text-slate-300" />
+                        <p>No orders match your search</p>
+                      </div>
+                    )}
                 </div>
               </CardContent>
             </Card>

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -21,7 +21,7 @@ export function toCsv(
 }
 
 export function downloadCsv(filename: string, csvString: string): void {
-  const blob = new Blob(["﻿" + csvString], {
+  const blob = new Blob(["\uFEFF" + csvString], {
     type: "text/csv;charset=utf-8;",
   });
   const url = URL.createObjectURL(blob);

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,35 @@
+export type CsvValue = string | number | boolean | null | undefined;
+
+export function escapeCsvField(value: CsvValue): string {
+  if (value === null || value === undefined) return "";
+  const str = String(value);
+  if (/[",\n\r]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+export function toCsv(
+  rows: Record<string, CsvValue>[],
+  columns: { key: string; label: string }[],
+): string {
+  const header = columns.map((c) => escapeCsvField(c.label)).join(",");
+  const body = rows
+    .map((row) => columns.map((c) => escapeCsvField(row[c.key])).join(","))
+    .join("\r\n");
+  return `${header}\r\n${body}`;
+}
+
+export function downloadCsv(filename: string, csvString: string): void {
+  const blob = new Blob(["﻿" + csvString], {
+    type: "text/csv;charset=utf-8;",
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- `/manage` Orders tab: replace the Status (Paid/Pending) column with University, add a search box (ref/name/email/phone/university), and an Export CSV button with a column picker covering all order fields (exports the currently-filtered rows).
- New `src/lib/csv.ts` helper (`toCsv`/`downloadCsv`), no new dependencies.
- Likely root cause of orders being permanently stuck at "pending": `createPaymentRecord` built the Jenga `callbackUrl`/signature from `process.env.SITE_URL` (a Convex deployment env var, separate from Vercel env vars) without validation. If unset/wrong, the callback URL given to Jenga is broken (e.g. `"undefined/api/pgw-webhook-4365c21f"`), so Jenga's webhook never arrives and `orders.paid` never flips — silently, for every transaction.
- `createPaymentRecord` now validates `SITE_URL` is a proper `http(s)://` URL with no trailing slash up front and throws/logs a clear error if not. `validateSigningEnvs()` now always (not just in `NODE_ENV=production`) checks `JENGA_MERCHANT_CODE`.

## Test plan
- [ ] `npx tsc --noEmit` / `npm run build` (passes locally)
- [ ] `/manage` -> Orders tab: confirm columns are Order Ref, Customer, T-Shirt, Amount, University, Date, Actions
- [ ] Search filters orders by ref/name/email/phone/university
- [ ] Export CSV: toggle columns, download, verify content/escaping and row count matches filtered table
- [ ] Run `npx convex env get SITE_URL --prod` to confirm/fix the callback root cause; set with `npx convex env set SITE_URL https://<domain> --prod` if missing, then redeploy
- [ ] End-to-end test payment: confirm webhook hits `/api/pgw-webhook-4365c21f` and `orders.paid` flips to true

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added order search to the management dashboard—filter orders by reference number, customer name, email address, phone number, or university
  * Added CSV export with customizable column selection—download filtered orders and choose which fields to include
  * Updated the orders table to display university information for each order, replacing the status column

<!-- end of auto-generated comment: release notes by coderabbit.ai -->