### PR TITLE
docs: homepage redesign research & design prompt kit

### DIFF
--- a/docs/homepage-redesign/01-deep-research-prompt.md
+++ b/docs/homepage-redesign/01-deep-research-prompt.md
@@ -1,0 +1,52 @@
+# Deep Research Prompt — Landing Pages for Cause-Driven Nonprofits
+
+Copy everything in the box below into Google's Deep Research (Gemini). When it finishes, export the report as Markdown and save it in this folder as `research-output.md`.
+
+---
+
+```
+Context: I'm researching how to design an effective homepage/landing page for
+a nonprofit organization. The organization is a Kenyan charity that funds
+tuition, accommodation, and meals for medical students in need, primarily
+through an annual charity run event. The homepage needs to both build trust
+with visitors and drive two kinds of action: event registrations/merchandise
+purchases (for the charity run) and a general sense of credibility that
+supports future donations.
+
+Research question: What does the research and best-practice literature say
+makes a landing page effective for a cause-driven, nonprofit, or fundraising
+organization?
+
+Please cover, in depth:
+
+1. Hero section best practices — how to balance emotional storytelling with
+   clarity about what the organization does and what action a visitor should
+   take.
+2. Calls-to-action — placement, framing, and number of CTAs (donate, register,
+   volunteer, learn more) that maximize conversion without overwhelming
+   visitors.
+3. Social proof and impact statistics — how organizations effectively use
+   numbers (people helped, funds raised, years active) and testimonials/photos
+   to build credibility.
+4. Storytelling structure — how origin stories, founder/beneficiary stories,
+   and "why this cause matters" narratives are typically structured on
+   high-performing nonprofit pages.
+5. Trust and transparency signals — governance/board information, financial
+   transparency, partner/sponsor logos, and how prominently these should
+   appear.
+6. Mobile-first donation and registration UX — differences between mobile and
+   desktop layouts, friction points in donation/registration flows, and how
+   top organizations reduce drop-off.
+7. Common anti-patterns and mistakes nonprofit landing pages make that hurt
+   conversion or trust.
+8. Any benchmark data on conversion rates, scroll depth, or section ordering
+   for nonprofit/cause landing pages.
+
+Where possible, cite specific studies, case studies, or named examples of
+organizations doing this well. Summarize findings in a way that could directly
+inform a homepage redesign brief.
+```
+
+---
+
+Once you have the report, export it as Markdown and save it as `docs/homepage-redesign/research-output.md`, then move on to [`02-design-prompt-generator.md`](./02-design-prompt-generator.md).

--- a/docs/homepage-redesign/02-design-prompt-generator.md
+++ b/docs/homepage-redesign/02-design-prompt-generator.md
@@ -1,0 +1,63 @@
+# Design Prompt Generator — LNMB Homepage
+
+After you have `research-output.md` saved in this folder, paste the prompt below into Claude, **and attach/paste the full contents of `research-output.md` along with it**. Claude will combine the research findings with LNMB's actual brand and content context to produce a single, ready-to-use design prompt for Stitch (or Claude, if Stitch isn't available).
+
+---
+
+```
+You are helping design a new homepage for LNMB ("Leave No Medic Behind"), a
+Kenyan nonprofit operating as the Prof Hassan Saidi Memorial Educational Fund.
+LNMB funds tuition, accommodation, and meals for medical students in need,
+primarily through an annual charity run event called "Strides of Compassion".
+
+I'm attaching a deep-research report on what makes landing pages effective for
+cause-driven/nonprofit organizations. Read it carefully.
+
+Here is LNMB's current context:
+
+- Current homepage sections: a hero with an image carousel of charity run
+  photos, headline "Leave No Medic Behind" with "Strides of Compassion" as a
+  script-style sub-brand, and two CTAs ("Get a T-Shirt" -> /register,
+  "Read Our Story" -> /story); an "Impact Snapshot" stats section (year
+  started 2017, biggest fundraiser = the annual charity run, 1,000+
+  participants annually, 50+ students helped) plus a "Medics Unite" blurb
+  about the memorial fund and a section on governance/accountability; an
+  "About the Cause" section with the founding story and a "Learn More" CTA
+  to /story.
+- Unused/disabled homepage sections that exist in code and could be revived:
+  a "mission" section, a "social" section (social media / community), a
+  generic "cta" section, and a "highlights" section.
+- Key destination pages: /shop (charity run registration & t-shirt purchase,
+  multi-step mobile-first flow), /story (origin story, timeline, governance),
+  /team, /partners, /highlights, /contact, /register.
+- Brand constraints (must follow exactly, see docs/colors.md): only these
+  colors - Navy #2D3748 (primary), Cyan #38BDF8 (accent), Red #EF4444
+  (destructive/highlight), Black #1A202C (text), White #FFFFFF (background).
+  No gradients. No arbitrary/AI-generated colors.
+
+Using the research findings plus this context, write a single, concrete,
+well-structured design prompt that I can paste into Stitch
+(https://stitch.withgoogle.com) to generate homepage design concepts. The
+prompt should:
+
+- Describe the homepage layout section-by-section (hero, impact/social proof,
+  mission/story, testimonials or highlights, final CTA), informed by what the
+  research says works best.
+- Specify tone and visual style (clean, trustworthy, mobile-first, photo-driven
+  given the charity run imagery).
+- Explicitly state the brand color constraints above and that no gradients or
+  off-brand colors should be used.
+- State the primary goals: drive registrations/merchandise purchases for the
+  charity run via /shop, and build enough trust/credibility to support
+  donations and partnerships.
+- Be a single self-contained prompt (not a list of options), ready to paste
+  directly into a design tool.
+
+At the end, add one short note: "If Stitch is unavailable, this same prompt
+can be pasted into Claude (e.g. Claude.ai or Claude Code) to generate design
+mockups or code instead."
+```
+
+---
+
+Save Claude's output as `docs/homepage-redesign/stitch-design-prompt.md`, then follow the instructions in [`README.md`](./README.md) for the design step.

--- a/docs/homepage-redesign/README.md
+++ b/docs/homepage-redesign/README.md
@@ -1,0 +1,49 @@
+# Homepage Redesign — Research & Design Prompt Kit
+
+This folder contains a self-contained workflow for researching and designing
+a new LNMB homepage, before any implementation work begins.
+
+## Workflow
+
+1. **Deep research.** Open [`01-deep-research-prompt.md`](./01-deep-research-prompt.md)
+   and copy the prompt into Google's Deep Research (Gemini).
+2. **Export research.** When the report is ready, export it as Markdown and
+   save it here as `research-output.md`.
+3. **Generate the design prompt.** Open
+   [`02-design-prompt-generator.md`](./02-design-prompt-generator.md), paste
+   that prompt into Claude along with the full contents of
+   `research-output.md`. Claude will produce a single design prompt tailored
+   to LNMB.
+4. **Save the design prompt** as `stitch-design-prompt.md`.
+5. **Generate designs.** Paste `stitch-design-prompt.md` into
+   [Stitch](https://stitch.withgoogle.com) to generate homepage design
+   concepts. If Stitch isn't available, paste the same prompt into Claude
+   (Claude.ai or Claude Code) instead.
+
+Track progress in [`TRACKER.md`](./TRACKER.md).
+
+## Brand constraints
+
+Whatever comes out of this process must stay within LNMB's brand system,
+documented in [`../colors.md`](../colors.md):
+
+- Colors: Navy `#2D3748` (primary), Cyan `#38BDF8` (accent), Red `#EF4444`
+  (destructive/highlight), Black `#1A202C` (text), White `#FFFFFF`
+  (background) — nothing else.
+- No gradients, no arbitrary/AI-generated colors.
+
+## Current homepage for reference
+
+The current homepage (`src/app/page.tsx`) renders:
+
+- **Hero** (`src/components/home/hero.tsx`) — image carousel, "Leave No
+  Medic Behind" / "Strides of Compassion" branding, CTAs to `/register` and
+  `/story`.
+- **Impact Snapshot** (`src/components/home/impact.tsx`) — key stats and
+  governance/accountability blurb.
+- **About** (`src/components/home/about.tsx`) — founding story with a
+  "Learn More" CTA to `/story`.
+
+Unused components that exist and could be revived during the redesign:
+`mission.tsx`, `home-social.tsx`, `cta.tsx`, `highlights.tsx` (all in
+`src/components/home/`).

--- a/docs/homepage-redesign/TRACKER.md
+++ b/docs/homepage-redesign/TRACKER.md
@@ -1,0 +1,13 @@
+# Homepage Redesign — Tracker
+
+Track progress through the research-to-design workflow described in [`README.md`](./README.md).
+
+| Step | Status | Owner | Date | Notes |
+| --- | --- | --- | --- | --- |
+| Run deep research prompt (`01-deep-research-prompt.md`) in Google Deep Research | [ ] | | | |
+| Save report as `research-output.md` | [ ] | | | |
+| Run design prompt generator (`02-design-prompt-generator.md`) with research output | [ ] | | | |
+| Save generated prompt as `stitch-design-prompt.md` | [ ] | | | |
+| Generate homepage design concepts in Stitch (or Claude) | [ ] | | | |
+| Review designs against `docs/colors.md` brand constraints | [ ] | | | |
+| Create follow-up implementation task/issue | [ ] | | | |


### PR DESCRIPTION
## Summary
- Adds a self-contained research-to-design workflow for the homepage redesign under `docs/homepage-redesign/`
- Includes a deep research prompt (for Google Deep Research), a design prompt generator (for Claude), a tracker, and a README tying it all together
- References existing brand constraints in `docs/colors.md`

## Test plan
- [ ] Markdown renders correctly on GitHub
- [ ] Links between docs resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)